### PR TITLE
feat: update ministers page, styling, and set default theme to dark

### DIFF
--- a/src/assets/styles/tailwind.css
+++ b/src/assets/styles/tailwind.css
@@ -42,6 +42,7 @@
   @apply bg-[#87ceeb]/80 backdrop-blur-md;
   /* @apply bg-page md:bg-white/90 md:backdrop-blur-md; */
   box-shadow: 0 0.375rem 1.5rem 0 rgb(140 152 164 / 13%);
+
 }
 .dark #header.scroll > div:first-child,
 #header.scroll.dark > div:first-child {

--- a/src/components/common/BasicScripts.astro
+++ b/src/components/common/BasicScripts.astro
@@ -1,8 +1,8 @@
 ---
-import { UI } from 'astrowind:config';
+
 ---
 
-<script is:inline define:vars={{ defaultTheme: UI.theme }}>
+<script is:inline define:vars={{ defaultTheme: 'dark' }}>
   if (window.basic_script) {
     return;
   }

--- a/src/components/widgets/Header.astro
+++ b/src/components/widgets/Header.astro
@@ -58,10 +58,28 @@ const currentPath = `/${trimSlash(new URL(Astro.url).pathname)}`;
 const { nav: navClass = '' } = classes;
 ---
 
+<style>
+  @keyframes slideDown {
+    from {
+      transform: translateY(-32%);
+      opacity: 0;
+    }
+    to {
+      transform: translateY(0);
+      opacity: 1;
+    }
+  }
+
+  .animate-slide-down {
+    animation: slideDown 1.2s ease-out forwards;
+  }
+</style>
+
 <header
   class:list={[
     { sticky: isSticky, relative: !isSticky, dark: isDark },
     'top-0 z-40 flex-none mx-auto w-full border-b border-gray-50/0 transition-[opacity] ease-in-out',
+    { 'animate-slide-down': currentPath === '/' },
   ]}
   {...isSticky ? { 'data-aw-sticky-header': true } : {}}
   {...id ? { id } : {}}
@@ -82,7 +100,7 @@ const { nav: navClass = '' } = classes;
     ]}
   >
     <div class:list={[{ 'mr-auto rtl:mr-0 rtl:ml-auto': position === 'right' }, 'flex justify-between']}>
-      <a class="items-center relative inline-block" href={getHomePermalink()}>
+      <a class="flex items-center" href={getHomePermalink()}>
         <Logo />
       </a>
       <div class="flex items-center lg:hidden">

--- a/src/components/widgets/ImageTextSection.astro
+++ b/src/components/widgets/ImageTextSection.astro
@@ -74,6 +74,13 @@ function getGridClasses(itemCount: number): string {
     return `${baseClasses} grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4`;
   }
 }
+
+const styleStyle = {
+  backgroundAttachment: 'local',
+  backgroundRepeat: 'repeat',
+  backgroundSize: '200% 100%',
+  backgroundPosition: '10% 20%',
+};
 ---
 
 <WidgetWrapper
@@ -96,7 +103,7 @@ function getGridClasses(itemCount: number): string {
     {
       groupedItems.map((group) => {
         if (group.type === 'content') {
-          const { isReversed, image, title, content, name } = group.item;
+          const { isReversed, image, title, content } = group.item;
           return (
             <div class="grid grid-cols-1 md:grid-cols-5 gap-8 md:items-center items-start intersect-once motion-safe:md:intersect:animate-fade motion-safe:md:opacity-0 intersect-tenth sm:intersect-quarter">
               <div
@@ -105,7 +112,7 @@ function getGridClasses(itemCount: number): string {
                 <Image
                   class="rounded-lg shadow-md w-full max-w-40 sm:max-w-52"
                   width={680}
-                  height={680}
+                  height={840}
                   widths={[300, 400, 680]}
                   layout="responsive"
                   {...image}
@@ -117,12 +124,16 @@ function getGridClasses(itemCount: number): string {
               >
                 <div class="border-b-2 border-primary-500 pb-2 w-full mb-4">
                   <h3 class="inline-flex xs:items-center flex-wrap flex-col xs:flex-row">
-                    <GradientText animate={false} class="text-2xl font-bold italic pr-px" set:html={title} />
-                    <span class="text-2xl font-bold px-4 hidden xs:block">-</span>
-                    <span class="font-signature text-4xl font-bold">{name}</span>
+                    <GradientText
+                      animate={false}
+                      imageNro={2}
+                      backgroundStyles={styleStyle}
+                      class="text-5xl font-bold font-signature italic pr-4"
+                      set:html={title}
+                    />
                   </h3>
                 </div>
-                <div class="prose prose-lg max-w-none" set:html={content} />
+                <div class="text-muted prose prose-lg max-w-none" set:html={content} />
               </div>
             </div>
           );
@@ -132,22 +143,26 @@ function getGridClasses(itemCount: number): string {
 
           return (
             <div class={gridClasses}>
-              {group.items.map(({ image, title, name }) => (
+              {group.items.map(({ image, title }) => (
                 <div class="flex flex-col items-center intersect-once motion-safe:intersect:animate-fade motion-safe:opacity-0 intersect-tenth sm:intersect-quarter">
                   <div class="flex justify-center mb-4">
                     <Image
                       class="rounded-lg shadow-md w-full max-w-40 sm:max-w-52"
                       width={680}
-                      height={680}
+                      height={840}
                       widths={[300, 400, 680]}
                       layout="responsive"
                       {...image}
                     />
                   </div>
                   <div class="text-center border-b-2 border-primary-500 pb-2 w-full mb-2">
-                    <h3 class="flex flex-col items-center gap-4">
-                      <GradientText animate={false} class="text-2xl font-bold italic px-2" set:html={title} />
-                      <span class="font-signature text-4xl font-bold">{name}</span>
+                    <h3 class="inline-flex xs:items-center flex-wrap flex-col xs:flex-row">
+                      <GradientText
+                        animate={false}
+                        backgroundStyles={styleStyle}
+                        class="text-5xl font-bold font-signature italic pr-4"
+                        set:html={title}
+                      />
                     </h3>
                   </div>
                 </div>

--- a/src/components/widgets/TestimonialCard.astro
+++ b/src/components/widgets/TestimonialCard.astro
@@ -10,10 +10,8 @@ const defaultBackgroundStyles = {
   color: 'transparent',
   backgroundRepeat: 'no-repeat',
   backgroundAttachment: 'local',
-  // backgroundPosition: '25% 0%',
   backgroundPosition: '0% 10%',
   backgroundSize: 'cover',
-  // backgroundSize: '200% 100%',
 };
 ---
 

--- a/src/components/widgets/Testimonials.astro
+++ b/src/components/widgets/Testimonials.astro
@@ -86,8 +86,8 @@ const lgThirdColumnItems = testimonials.slice(2 * thirdCount);
       {/* Third column - Only visible on large screens */}
       <div class="hidden lg:block space-y-6">
         {
-          lgThirdColumnItems.map((testimonial, index) => (
-            <div class={index > 0 ? 'mt-6' : ''}>
+          lgThirdColumnItems.map((testimonial) => (
+            <div class={`mt-6`}>
               <TestimonialCard {...testimonial} />
             </div>
           ))

--- a/src/data/ministers.ts
+++ b/src/data/ministers.ts
@@ -1,22 +1,12 @@
 // import ahunsi from '~/assets/images/elders/ahunsi.webp';
 import akosua from '~/assets/images/deacons/akosua.webp';
-import ben from '~/assets/images/deacons/ben.webp';
+// import ben from '~/assets/images/deacons/ben.webp';
 import ida from '~/assets/images/deacons/ida.webp';
 // import cj from '~/assets/images/elders/cj.webp';
 import greta from '~/assets/images/elders/greta.jpg';
 import juhani_helsinki from '~/assets/images/elders/juhani_helsinki.webp';
+import mahi from '~/assets/images/elders/mahi_enhanced.webp';
 
-// import mahi from '~/assets/images/elders/mahi.webp';
-
-// {
-//   title: 'Paimen',
-//   name: 'Mahidere Ali',
-//   image: {
-//     src: mahi,
-//     alt: 'Mahidere - kuva',
-//   },
-//   isReversed: true,
-// },
 // {
 //   title: 'Paimen',
 //   name: 'CJ',
@@ -40,7 +30,7 @@ export const ministers = [
   {
     // <br /> <br />
     // 2) Nyt ymmärsin sen. Jumala sanoi Jeesukselle, 'Tämä on rakas poikani johon olen mieltynyt'. Sananlaskut 16:7 sanoo, 'Kun miehen tiet miellyttävät Herraa, Hän saataa hänen vihollisensa hänen ystävikseen'. Eivät fariseukset ja kansa rakastaneet ja halanneet Jeesusta vaan ristiinnaulitsivat Hänet, 1 Kor 2:8, 'Jos he olisivat tietäneet he eivät olisi ristiinnaulinneet kirkkauden Herraa'. Eli kun sinun tiesi miellyttää Jumalaa Hän saattaa sinun vihollistesi kaikkien tekojen sinua kohtaan olevan kuin ystävän palveluksia! Eli vaikka kuinka he vainoaisivat sinua tai vihaisivat sinua, kaikki mitä he tekevät, on kuin ystävän tekoja sinulle! Vau! Kiitos Jeesus!!
-    title: 'Valvoja (Piispa)',
+    title: 'Piispa Juhani Juusola',
     name: 'Juhani Juusola',
     content: `1) Tämä on Herran sana: tuo henkilö joutuu lähtemään pois työpaikastasi. Hän ei pysty kestämään tätä Jumalan tulta sinussa.
     <br /> <br />
@@ -52,12 +42,21 @@ export const ministers = [
     isReversed: false,
   },
   {
-    title: 'Paimen',
-    name: 'Greta Juusola',
-    content: `1) *****n argumentti: ‘Mutta sinä et ymmärrä, kun sinulla ei ole lapsia.’ 
-      Gretan vastaus: ’Ei olekaan, mutta minä tiedän mitä Raamattu sanoo ja Raamattu sanoo että kädenlämpöisyys ja että jos mikään asia on tärkeämpi kuin Jumala, niin se on väärin.’
-      <br /> <br />
-      2) Kun vaellamme Kristuksen tiellä täysin antautuneena, olemme täydellisiä niin kuin itse Kristus on. Niin kauan kun emme katso lihaan, Jumala kyllä ilmoittaa kaikesta miten asiat ovat. Fil. 3:12-16`,
+    title: 'Paimen Mahidere',
+    name: 'Mahidere',
+    image: {
+      src: mahi,
+      alt: 'Mahidere - kuva',
+    },
+    isReversed: true,
+  },
+  {
+    title: 'Paimen Greta',
+    name: 'Greta',
+    // content: `1) *****n argumentti: ‘Mutta sinä et ymmärrä, kun sinulla ei ole lapsia.’
+    //   Gretan vastaus: ’Ei olekaan, mutta minä tiedän mitä Raamattu sanoo ja Raamattu sanoo että kädenlämpöisyys ja että jos mikään asia on tärkeämpi kuin Jumala, niin se on väärin.’
+    //   <br /> <br />
+    //   2) Kun vaellamme Kristuksen tiellä täysin antautuneena, olemme täydellisiä niin kuin itse Kristus on. Niin kauan kun emme katso lihaan, Jumala kyllä ilmoittaa kaikesta miten asiat ovat. Fil. 3:12-16`,
     image: {
       src: greta,
       alt: 'Rakas Greta - kuva',
@@ -65,8 +64,8 @@ export const ministers = [
     isReversed: true,
   },
   {
-    title: 'Seurakunta Palvelija',
-    name: 'Akosua Osei',
+    title: 'Seurakunnan palvelija Akosua',
+    name: 'Akosua',
     content: `1) Ihmiset ilman Jumalan Henkeä sisimmässään olivat uskonnollisia. Siksi heidän puheensa ei tuonut synnintuntoa toisille. Stefanos taas oli mies täynnä Pyhää Henkeä. Tämä tarkoitti, että hänen suustaan lähtevät sanat toivat synnintunnon kuulijoiden sydämiin. Uskonnolliset ihmiset olisivat halunneet jonkun toisen puhuvan, koska silloin he olisivat voineet elää niin kuin elivät ilman synnintuntoa.
               <br /> <br />
               2) Raamattu komentaa meitä etsimään ja asettamaan mielemme niihin asioihin, jotka ovat ylhäällä ja ikuisia. Stefanos piti mielensä aina ikuisissa asioissa. Ja kun uskonnollinen väkijoukko alkoi kiristellä hampaitaan hänelle, Stefanos katsoi taivaaseen. Hän oli tottunut siihen, eikä hän keskittynyt ollenkaan ihmisten  reaktioihin. Hän oli toki täynnä Pyhää Henkeä ja Henki kykeni ohjaamaan hänen silmänsä ylös. Siitä huolimatta hän keskittyi itse ylhäällä oleviin asioihin.
@@ -79,8 +78,8 @@ export const ministers = [
     isReversed: false,
   },
   {
-    title: 'Seurakunta Palvelija',
-    name: 'Ida Pikkarainen',
+    title: 'Seurakunnan palvelija Ida',
+    name: 'Ida',
     content: `1) Kun rukoilimme, näin kun Mahi oli verkossa. Monta kalastajan verkkoa oli kietoutunut hánen ympärilleen ja hän oli aivan jumissa. Hän oli sikiöasennossa ja ei pystynyt liikkumaan. Mutta sitten rukoillessamme verkon punokset alkoivat erkaantua toisistaan. Verkot hajosivat itsestään, kunnes niistä ei ollut jäljellä mitään. Sitten Mahi nousi ylös ja lähti liikkeelle niin iloisena Herran antamasta vapaudesta. Halleluja!!`,
     image: {
       src: ida,
@@ -88,13 +87,13 @@ export const ministers = [
     },
     isReversed: true,
   },
-  {
-    title: 'Seurakunta Palvelija',
-    name: 'Benwillis Onchonga',
-    image: {
-      src: ben,
-      alt: 'Benwillis - kuva',
-    },
-    isReversed: true,
-  },
+  // {
+  //   title: 'Seurakunnan palvelija Benwillis',
+  //   name: 'Benwillis',
+  //   image: {
+  //     src: ben,
+  //     alt: 'Benwillis - kuva',
+  //   },
+  //   isReversed: true,
+  // },
 ];

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,7 +3,7 @@ import akosua from '~/assets/images/deacons/akosua.webp';
 import ben from '~/assets/images/deacons/ben.webp';
 import ida from '~/assets/images/deacons/ida.webp';
 import cj from '~/assets/images/elders/cj.webp';
-import mahi from '~/assets/images/elders/mahi.webp';
+import mahi from '~/assets/images/elders/mahi_enhanced.webp';
 import prayerConference from '~/assets/images/other/Kuopio Prayer conference_ April 2025_finnish.webp';
 import logo from '~/assets/images/other/logo.webp';
 import imgPrayerChurchKuopio from '~/assets/images/other/prayer_church_kuopio2.webp';
@@ -67,7 +67,6 @@ const styleStyle = {
   >
     <Fragment slot="title">
       <GradientText
-        isHeading={true}
         imageNro={2}
         class="w-full text-[12vw] sm:text-[14vw] md:text-[12vw] lg:text-[10vw] font-bold leading-none"
         backgroundStyles={styleStyle}
@@ -555,7 +554,7 @@ const styleStyle = {
   <Spacer size="md" />
 
   <div class="mx-auto -my-4 text-center relative z-0 h-[20rem] sm:h-[24rem] lg:h-[40rem] w-full overflow-hidden mb-20">
-    <div class="absolute -right-20 top-10 sm:top-0 md:top-0 lg:top-0 -translate-y-0 w-full h-full">
+    <div class="absolute -right-20 top-0 -translate-y-0 w-full h-full">
       <div class="relative w-full h-full">
         <!-- Oval-like highlight area with radial gradient -->
         <div


### PR DESCRIPTION
# Pull Request

## 📝 Description
Updated the ministers section with improved styling and content organization

### What changed?
- Set default theme to 'dark' in BasicScripts component
- Enhanced ImageTextSection component with improved styling:
  - Updated image dimensions (height from 680 to 840)
  - Added custom background style for gradient text
  - Simplified title display by removing name/title separation
  - Improved text styling with font-signature class
- Updated ministers data:
  - Added Mahidere as a minister with enhanced image
  - Refined title formatting for all ministers (e.g., "Piispa Juhani Juusola" instead of separate title/name)
  - Temporarily commented out Ben's entry
- Fixed spacing in Testimonials component
- Added minor CSS styling improvements

## 📌 Additional Notes
The changes focus on improving the visual presentation of ministers while maintaining a consistent styling approach throughout the site.

## 🔍 Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (would cause existing functionality to not work)
- [ ] 📚 Documentation update
- [x] 🎨 Style/UI update
- [x] ♻️ Code refactoring
- [ ] 📦 Dependency update
- [ ] 🧪 Test update
- [x] 🔧 Configuration change

## ✅ Checklist
### Code Quality
- [x] 👀 I have performed a self-review
- [x] ⚠️ No new warnings or errors are generated

### Git Hygiene
- [x] 🔍 My commits are small and have clear messages
- [x] 🧩 This PR is small and focused on a single change

## 🧪 Testing
- [x] 👉 Manual testing