### PR TITLE
fix: hide menu bottom language picker on mobile

### DIFF
--- a/src/components/widgets/Header.astro
+++ b/src/components/widgets/Header.astro
@@ -224,7 +224,7 @@ const navigateToLanguage = (href: string | undefined) => {
       ]}
     >
       <div class="items-center flex justify-between w-full lg:w-auto">
-        <div class="flex">
+        <div class="hidden lg:flex">
           <LanguagePicker />
           {
             actions?.length ? (


### PR DESCRIPTION
o# 🚀 Pull Request

## 📝 Description
Hide language picker on mobile devices, only showing it on large screens

### What changed?
- Modified the language picker container div to include `hidden lg:flex` instead of just `flex`, making it visible only on large screens (lg breakpoint and above)

## 📌 Additional Notes
This change improves the mobile UI by removing the language picker from smaller screens where space is limited.

## 🔗 Related Issues
🔄 Closes #

## 🔍 Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (would cause existing functionality to not work)
- [ ] 📚 Documentation update
- [x] 🎨 Style/UI update
- [ ] ♻️ Code refactoring
- [ ] 📦 Dependency update
- [ ] 🧪 Test update
- [ ] 🔧 Configuration change

## ✅ Checklist
### Code Quality
- [x] 👀 I have performed a self-review
- [ ] 💬 I have added necessary comments
- [x] ⚠️ No new warnings or errors are generated
- [ ] ⚡ I have added/updated tests

### Git Hygiene
- [x] 🔍 My commits are small and have clear messages
- [x] 🔀 I have rebased on the latest main branch
- [x] 🧩 This PR is small and focused on a single change

## 🧪 Testing
- [x] 👉 Manual testing