### PR TITLE
feat: add podcasts page with localized search placeholder

### DIFF
--- a/src/components/filters/FilterContainer.astro
+++ b/src/components/filters/FilterContainer.astro
@@ -1,5 +1,6 @@
 ---
 import WidgetWrapper from '~/components/ui/WidgetWrapper.astro';
+import { getLangFromUrl, useTranslations } from '~/i18n/utils';
 import ReactFilterContainer from './ReactFilterContainer';
 
 interface Props {
@@ -31,11 +32,15 @@ const containerId =
   `filter-container-${JSON.stringify(options)
     .split('')
     .reduce((a, b) => ((a << 5) - a + b.charCodeAt(0)) | 0, 0)}`;
+
+const lang = getLangFromUrl(Astro.url);
+const t = useTranslations(lang);
 ---
 
 <WidgetWrapper id={containerId} isDark={isDark} containerClass={classes?.container ?? `max-w-7xl mx-auto`} bg={bg}>
   <ReactFilterContainer
     client:load
+    textSearchPlaceholder={t('search')}
     options={options}
     allLabels={allLabels}
     showSearch={showSearch}

--- a/src/components/filters/ReactFilterContainer.tsx
+++ b/src/components/filters/ReactFilterContainer.tsx
@@ -12,6 +12,7 @@ const styles = `
 ` as const;
 
 interface FilterContainerProps {
+  textSearchPlaceholder: string;
   options: string[] | (string[] | string[][])[];
   allLabels: string[];
   showSearch?: boolean;
@@ -20,6 +21,7 @@ interface FilterContainerProps {
 }
 
 export default function ReactFilterContainer({
+  textSearchPlaceholder,
   options,
   allLabels,
   showSearch = true,
@@ -236,7 +238,7 @@ export default function ReactFilterContainer({
                   id={gridId ? `${gridId}-quick-filter` : 'search-input'}
                   type='text'
                   className='w-full px-4 py-2 rounded-lg border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-600'
-                  placeholder='Search...'
+                  placeholder={textSearchPlaceholder}
                   value={filters.search}
                   onChange={handleSearch}
                   data-search-input

--- a/src/components/widgets/SpeechBubbleIcon.astro
+++ b/src/components/widgets/SpeechBubbleIcon.astro
@@ -40,19 +40,18 @@ const t = useTranslations(lang);
     class={`fixed z-[9999] ${iconPosition} ${iconSize} ${classes.container || ''} opacity-0 pointer-events-none transition-opacity duration-500 group cursor-pointer no-movement`}
   >
     <div class="relative">
-      <!-- Icon wrapper to prevent movement -->
-      <div class="icon-wrapper">
+      <!-- Icon wrapper to prevent movement - hidden on mobile -->
+      <div class="lg:block hidden">
         <Icon
           name="tabler:info-circle-filled"
           class={`text-primary-600 drop-shadow-lg ${iconSize} ${classes.icon || ''} group-hover:scale-110 transition-transform no-movement`}
         />
-        <div class="absolute -top-1 -right-1 w-3 h-3 bg-primary-600 rounded-full animate-pulse"></div>
       </div>
 
       <!-- Tooltip that appears on hover (desktop) or by default (mobile) -->
       <div
         id="speech-bubble-tooltip"
-        class="absolute flex flex-col bottom-full items-start justify-start right-0 mb-2 w-max max-w-[200px] bg-white/90 text-black text-sm p-2 rounded shadow-lg opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none no-movement"
+        class="absolute flex flex-col bottom-full items-start justify-start right-0 mb-2 w-max max-w-[200px] bg-white/90 text-black text-sm p-2 rounded shadow-lg opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none no-movement speech-bubble"
       >
         <!-- Close button (X) for mobile - hidden by default -->
         <button
@@ -79,7 +78,7 @@ const t = useTranslations(lang);
   // Check if we're on a mobile device
   function isMobileDevice() {
     return (
-      window.innerWidth <= 768 ||
+      window.innerWidth <= 1000 ||
       navigator.userAgent.match(/Android/i) ||
       navigator.userAgent.match(/iPhone|iPad|iPod/i)
     );
@@ -101,8 +100,10 @@ const t = useTranslations(lang);
       speechBubble.classList.remove('opacity-0', 'pointer-events-none');
       speechBubble.classList.add('opacity-100');
 
-      // Always add bounce animation for both mobile and desktop
-      speechBubble.classList.add('animate-bounce-gentle');
+      // Only add bounce animation for desktop
+      if (!isMobileDevice()) {
+        speechBubble.classList.add('animate-bounce-gentle');
+      }
     }, 10);
 
     // For mobile devices, show the tooltip by default and make it interactive
@@ -235,12 +236,6 @@ const t = useTranslations(lang);
     z-index: 9999;
   }
 
-  /* Icon wrapper to prevent movement */
-  .icon-wrapper {
-    display: inline-block;
-    position: relative;
-  }
-
   /* Transition for opacity is now handled by Tailwind classes */
   #speech-bubble-icon {
     will-change: opacity, transform;
@@ -271,18 +266,22 @@ const t = useTranslations(lang);
   }
 
   /* Mobile-specific styles */
-  @media (max-width: 768px) {
+  @media (max-width: 1000px) {
     #speech-bubble-tooltip {
       /* Ensure tooltip is visible and interactive on mobile */
-      position: absolute;
+      position: fixed;
       max-width: 200px;
       width: max-content;
+      bottom: auto;
+      right: 4px;
+      top: 4px;
     }
 
     #speech-bubble-close-btn {
       cursor: pointer;
       padding: 2px;
       border-radius: 50%;
+      display: block;
     }
 
     #speech-bubble-close-btn:hover {
@@ -293,5 +292,17 @@ const t = useTranslations(lang);
   /* Debug styles */
   .speech-bubble-visible {
     border: 2px solid transparent;
+  }
+
+  /* Speech bubble triangle */
+  .speech-bubble::after {
+    content: '';
+    position: absolute;
+    bottom: -10px;
+    right: 10px;
+    border-width: 10px 10px 0;
+    border-style: solid;
+    border-color: rgba(255, 255, 255, 0.9) transparent transparent transparent;
+    filter: drop-shadow(0 1px 1px rgba(0, 0, 0, 0.1));
   }
 </style>

--- a/src/data/videosAndPodcasts.ts
+++ b/src/data/videosAndPodcasts.ts
@@ -1,0 +1,46 @@
+import { groupByYear } from '~/utils/dataProcessing';
+import type { ImageMetadata } from 'astro';
+import { parseISO } from 'date-fns';
+
+interface MediaItem {
+  title: string;
+  date: string;
+  description: string;
+  videoId: string;
+  platform: 'Youtube' | 'Vimeo' | 'Doccheck' | 'Soundcloud' | 'Spotify' | 'Other';
+  author?: string;
+  trackUrl?: string;
+  poster?: ImageMetadata;
+  video?: string;
+  videoQuality?: 'max' | 'hq';
+}
+
+export const videosAndPodcasts: MediaItem[] = [
+  {
+    title: 'podcast1',
+    date: '2025-03-22',
+    description: 'podcast1.description',
+    videoId: 'asqmiQW7hY0',
+    platform: 'Youtube',
+  },
+];
+
+// Get unique platforms for filter buttons
+export const platforms = [...new Set(videosAndPodcasts.map((item) => item.platform))];
+
+// Group publications by year and sort within each year by date
+export const videosAndPodcastsByYear = groupByYear(videosAndPodcasts);
+
+// Sort publications within each year by date
+Object.keys(videosAndPodcastsByYear).forEach((year) => {
+  videosAndPodcastsByYear[Number(year)].sort((a, b) => {
+    const dateA = parseISO(a.date);
+    const dateB = parseISO(b.date);
+    return dateB.getTime() - dateA.getTime();
+  });
+});
+
+// Sort years in descending order
+export const sortedYears = Object.keys(videosAndPodcastsByYear)
+  .map(Number)
+  .sort((a, b) => b - a);

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -7,6 +7,7 @@ export const defaultLang = 'fi';
 
 export const ui = {
   en: {
+    podcasts: 'Podcasts',
     prayerChurchImageAlt: 'Prayer church logo',
     prayer: 'Prayer',
     church: 'Church',
@@ -297,8 +298,16 @@ Thank you, Jesus!
     icon: ' icon',
     toReadTheFullTestimony: 'to read the full testimony',
     clickOnTestimonialsToReadMore: 'Click to read full testimonies',
+    podcast1: 'Flame the Freeze Bible Study 04/01/25',
+    'podcast1.description': '2025 is the year of commanding battalions, why?',
+    podcastsFrom: 'Podcasts from the Flame the Freeze Bible Studies',
+    podcastSubtitle:
+      'Kaikki eivät puhu tai ymmärrä englantia. Siksi halusimme valmistaa näistä Hengen täytesistä raamiksista lyhyen suomenkielisen läpikäynnin, jotta myös suomenkieliset pääsevät näistä taivaallisista ilmestyksistä. Ja me olemme myös itse tulleet aivan valtavan siunatuiksi kuvatessamme näitä, sillä Pyhä Henki on ollut kuvaussessioiden vetäjä. Hallelujah!',
+    search: 'Search..',
+    allSubjects: 'All subjects',
   },
   fi: {
+    podcasts: 'Podkastit',
     prayerChurchImageAlt: 'Rukouksen seurakunnan logo',
     prayer: 'Rukouksen',
     church: 'seurakunta',
@@ -600,5 +609,12 @@ On aivan ihmeellistä, että minut on vapautettu, jotta voin nyt vapauttaa muita
     icon: ' -ikonia',
     toReadTheFullTestimony: 'lukeaksesi koko todistuksen',
     clickOnTestimonialsToReadMore: 'Klikkaa lukeaksesi koko todistuksen',
+    podcastsFrom: 'Podkastit Flame the Freeze raamiksista',
+    podcastSubtitle:
+      'Kaikki eivät puhu tai ymmärrä englantia. Siksi halusimme valmistaa näistä Hengen täytesistä raamiksista lyhyen suomenkielisen läpikäynnin, jotta myös suomenkieliset pääsevät näistä taivaallisista ilmestyksistä. Ja me olemme myös itse tulleet aivan valtavan siunatuiksi kuvatessamme näitä, sillä Pyhä Henki on ollut kuvaussessioiden vetäjä. Hallelujah!',
+    podcast1: 'Flame the Freeze raamis 04/01/25',
+    'podcast1.description': '2025 on pataljoonien komentamisen vuosi, miksi?',
+    search: 'Hae..',
+    allSubjects: 'Kaikki aiheet',
   },
 } as const;

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -19,5 +19,9 @@ export const headerData: { links: Array<MenuLink> } = {
       text: 'forYou',
       href: getPermalink('#sinulle'),
     },
+    // {
+    //   text: 'podcasts',
+    //   href: getPermalink('/podcasts'),
+    // },
   ],
 };

--- a/src/pages/en/podcasts.astro
+++ b/src/pages/en/podcasts.astro
@@ -1,0 +1,5 @@
+---
+import Index from '../podcasts.astro';
+---
+
+<Index />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -35,13 +35,13 @@ import { twMerge } from 'tailwind-merge';
 const metadata = {
   title: 'Rukouksen seurakunta | Meidän tulemme ei ole asia, vaan henkilö.. Jeesus',
   description:
-    'Rukouksen seurakunta on ryhmä, joka keskittyy Jeesukseen, intohimoiseen rukoukseen, Hengen ja Sanan täyttämään elämään, sekä herätyksen levittämiseen. Tule mukaan rukouskokouksiin ja kohtaa Jeesus. Savilahti, Kuopio.',
+    'Rukouksen seurakunta on Kuopiossa kokoontuva ryhmä, joka keskittyy Jeesukseen, intohimoiseen rukoukseen, Hengen ja Sanan täyttämään elämään, sekä herätyksen levittämiseen. Tule mukaan rukouskokouksiin ja kohtaa Jeesus. Savilahti, Kuopio.',
   ignoreTitleTemplate: true,
   canonical: 'https://rukouksenseurakunta.fi',
   openGraph: {
     title: 'Rukouksen seurakunta | Meidän tulemme ei ole asia, vaan henkilö.. Jeesus',
     description:
-      'Rukouksen seurakunta on ryhmä, joka keskittyy Jeesukseen, intohimoiseen rukoukseen, Hengen ja Sanan täyttämään elämään, sekä herätyksen levittämiseen. Tule mukaan rukouskokouksiin ja kohtaa Jeesus.',
+      'Rukouksen seurakunta on Kuopiossa kokoontuva ryhmä, joka keskittyy Jeesukseen, intohimoiseen rukoukseen, Hengen ja Sanan täyttämään elämään, sekä herätyksen levittämiseen. Tule mukaan rukouskokouksiin ja kohtaa Jeesus.',
     type: 'website',
     image: logo,
     article: {

--- a/src/pages/podcasts.astro
+++ b/src/pages/podcasts.astro
@@ -1,0 +1,80 @@
+---
+import logo from '~/assets/images/other/logo.webp';
+import FilterContainer from '~/components/filters/FilterContainer.astro';
+import GradientText from '~/components/ui/GradientText.astro';
+import Hero from '~/components/widgets/Hero.astro';
+import VideosAndPodcastsList from '~/components/widgets/list/VideosAndPodcastsList.astro';
+import Spacer from '~/components/widgets/Spacer.astro';
+import { platforms } from '~/data/videosAndPodcasts';
+import { getLangFromUrl, useTranslations } from '~/i18n/utils';
+import Layout from '~/layouts/PageLayout.astro';
+
+const metadata = {
+  title: 'Rukouksen seurakunta | Seurakunnan podkastit',
+  description:
+    'Rukouksen seurakunta on Kuopiossa kokoontuva ryhmä, joka keskittyy Jeesukseen, intohimoiseen rukoukseen, Hengen ja Sanan täyttämään elämään, sekä herätyksen levittämiseen. Tule mukaan rukouskokouksiin ja kohtaa Jeesus. Savilahti, Kuopio.',
+  ignoreTitleTemplate: true,
+  canonical: 'https://rukouksenseurakunta.fi',
+  openGraph: {
+    title: 'Rukouksen seurakunta | Seurakunnan podkastit',
+    description:
+      'Rukouksen seurakunta on Kuopiossa kokoontuva ryhmä, joka keskittyy Jeesukseen, intohimoiseen rukoukseen, Hengen ja Sanan täyttämään elämään, sekä herätyksen levittämiseen. Tule mukaan rukouskokouksiin ja kohtaa Jeesus.',
+    type: 'website',
+    image: logo,
+    article: {
+      publishedTime: '2025-03-03T05:03:23+02:00',
+      modifiedTime: '2025-03-03T05:03:23+02:00',
+      authors: ['Rukouksen seurakunta'],
+      tags: [
+        'Rukouksen seurakunta',
+        'Rukouksen seurakunta Kuopio',
+        'Savilahti',
+        'Kuopio',
+        'Savilahden seurakunta',
+        'Kuopio seurakunta',
+      ],
+    },
+  },
+  twitter: {
+    handle: '@RukouksenSrk',
+    site: '@RukouksenSrk',
+    cardType: 'summary_large_image',
+  },
+};
+
+const styleStyle = {
+  backgroundPosition: 'center',
+  backgroundAttachment: 'local',
+  backgroundRepeat: 'repeat',
+  backgroundSize: '100% 100%',
+};
+
+const lang = getLangFromUrl(Astro.url);
+const t = useTranslations(lang);
+---
+
+<Layout metadata={metadata}>
+  <Hero tagline={t('podcasts')} subtitle={t('podcastSubtitle')}>
+    <Fragment slot="title">
+      <GradientText imageNro={2} isHeading backgroundStyles={styleStyle}>
+        {t('podcastsFrom')}
+      </GradientText>
+    </Fragment>
+  </Hero>
+
+  <FilterContainer
+    options={[platforms]}
+    allLabels={[t('allSubjects')]}
+    showSearch={true}
+    targetId="videos-and-podcasts-list"
+    classes={{
+      container: 'py-0 lg:py-0 md:py-0 mb-8',
+    }}
+  />
+
+  <div id="videos-and-podcasts-list">
+    <VideosAndPodcastsList />
+  </div>
+
+  <Spacer size="sm" />
+</Layout>


### PR DESCRIPTION
# Pull Request

## 📝 Description
Added internationalization support for search placeholders and implemented a new podcasts page with filtering functionality.

### What changed?
- Added translation for search placeholder text in filter components
- Created a new podcasts page with multilingual support
- Implemented a data structure for videos and podcasts content
- Enhanced the SpeechBubbleIcon component with improved mobile responsiveness
- Added a speech bubble triangle styling for better visual feedback
- Added new translations for podcast-related content

## 📌 Additional Notes
The podcasts navigation link is currently commented out in the navigation.ts file, suggesting this feature may be in development or pending final approval.

## 🔗 Related Issues
🔄 Closes #
- 

## 🔍 Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (would cause existing functionality to not work)
- [ ] 📚 Documentation update
- [x] 🎨 Style/UI update
- [ ] ♻️ Code refactoring
- [ ] 📦 Dependency update
- [ ] 🧪 Test update
- [ ] 🔧 Configuration change

## ✅ Checklist
### Code Quality
- [x] 👀 I have performed a self-review
- [x] 💬 I have added necessary comments
- [x] ⚠️ No new warnings or errors are generated
- [ ] ⚡ I have added/updated tests

### Git Hygiene
- [x] 🔍 My commits are small and have clear messages
- [x] 🔀 I have rebased on the latest main branch
- [x] 🧩 This PR is small and focused on a single change

## 🧪 Testing
- [x] 👉 Manual testing