### PR TITLE
feat: add testimonial counter with localization support

### DIFF
--- a/src/components/widgets/Testimonials.astro
+++ b/src/components/widgets/Testimonials.astro
@@ -1,10 +1,12 @@
 ---
+import imgGold2 from '~/assets/images/gold_original.webp';
 import imgGold from '~/assets/images/gold_small.webp';
 import Button from '~/components/ui/Button.astro';
 import Headline from '~/components/ui/Headline.astro';
 import WidgetWrapper from '~/components/ui/WidgetWrapper.astro';
 import TestimonialCard from '~/components/widgets/TestimonialCard.astro';
 import TestimonialCardContainer from '~/components/widgets/TestimonIalCardContainer';
+import { getLangFromUrl, useTranslations } from '~/i18n/utils';
 import type { Testimonials as Props } from '~/types';
 
 const {
@@ -19,6 +21,9 @@ const {
   classes = {},
   bg = await Astro.slots.render('bg'),
 } = Astro.props;
+
+const lang = getLangFromUrl(Astro.url);
+const t = useTranslations(lang);
 
 // Calculate total testimonials
 const totalTestimonials = testimonials.length;
@@ -302,6 +307,23 @@ const defaultBackgroundStyles = {
       subtitle: 'text-xl',
     }}
   />
+
+  <!-- Testimonial counter -->
+  <div class="pb-4 w-full items-end flex justify-end">
+    <div
+      class="relative rounded-full p-0.5 w-24"
+      style={{
+        backgroundImage: `url(${imgGold2.src})`,
+        backgroundSize: 'cover',
+        backgroundPosition: 'center',
+        backgroundRepeat: 'no-repeat',
+      }}
+    >
+      <div class="flex items-center gap-2 px-6 py-2 text-sm font-medium rounded-full bg-page">
+        <span class="font-semibold">{totalTestimonials}{t('kpl')}</span>
+      </div>
+    </div>
+  </div>
 
   <div class="section" {...id ? { id: 'testimonialsContainer' } : {}}>
     <TestimonialCardContainer client:load>

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -308,6 +308,7 @@ Thank you, Jesus!
     commandingBattalions: 'Commanding battalions',
     wisdom: 'Wisdom',
     other: 'Other',
+    kpl: ' pcs',
   },
   fi: {
     podcasts: 'Podkastit',
@@ -622,5 +623,6 @@ On aivan ihmeellistä, että minut on vapautettu, jotta voin nyt vapauttaa muita
     commandingBattalions: 'Pataljoonien komentaminen',
     wisdom: 'Viisaus',
     other: 'Muut',
+    kpl: ' kpl',
   },
 } as const;


### PR DESCRIPTION
# Pull Request

## 📝 Description
Added a testimonial counter to display the total number of testimonials with localization support.

### What changed?
- Added a testimonial counter component that displays the total number of testimonials
- Imported a new gold background image for the counter styling
- Added localization strings for "pcs" (pieces) in both English and Finnish
- Implemented i18n support for the counter text

## 📌 Additional Notes
The counter is styled with a gold background and positioned at the top-right of the testimonials section.

## 🔗 Related Issues
🔄 Closes #

## 🔍 Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (would cause existing functionality to not work)
- [ ] 📚 Documentation update
- [x] 🎨 Style/UI update
- [ ] ♻️ Code refactoring
- [ ] 📦 Dependency update
- [ ] 🧪 Test update
- [ ] 🔧 Configuration change

## ✅ Checklist
### Code Quality
- [x] 👀 I have performed a self-review
- [ ] 💬 I have added necessary comments
- [x] ⚠️ No new warnings or errors are generated
- [ ] ⚡ I have added/updated tests

### Git Hygiene
- [x] 🔍 My commits are small and have clear messages
- [x] 🔀 I have rebased on the latest main branch
- [x] 🧩 This PR is small and focused on a single change

## 🧪 Testing
- [x] 👉 Manual testing