### PR TITLE
fix: update testimonial image breakpoint from xl to 2xl

### DIFF
--- a/src/components/widgets/TestimonialCard.astro
+++ b/src/components/widgets/TestimonialCard.astro
@@ -141,12 +141,12 @@ const imageUrl = typeof image === 'string' ? image : image?.src ? image.src : ''
         </div>
         {
           image && (
-            <div class={`min-h-12 min-w-12 xl:min-h-16 xl:min-w-16 rounded-full border border-slate-600`}>
+            <div class={`min-h-12 min-w-12 2xl:min-h-16 2xl:min-w-16 rounded-full border border-slate-600`}>
               {typeof image === 'string' ? (
                 <Fragment set:html={image} />
               ) : (
                 <Image
-                  class={`min-h-12 min-w-12 xl:min-h-16 xl:min-w-16 rounded-full border border-slate-600`}
+                  class={`min-h-12 min-w-12 2xl:min-h-16 2xl:min-w-16 rounded-full border border-slate-600`}
                   width={48}
                   height={48}
                   widths={[400, 768]}


### PR DESCRIPTION
# Pull Request

## 📝 Description
Update testimonial card image responsive breakpoints from `xl` to `2xl`

### What changed?
- Changed responsive breakpoint classes for testimonial images from `xl:min-h-16 xl:min-w-16` to `2xl:min-h-16 2xl:min-w-16`
- Applied this change to both the container div and the Image component

## 📌 Additional Notes
This change ensures testimonial images will maintain their smaller size until larger viewport widths, improving the responsive design.

## 🔗 Related Issues
🔄 Closes #

## 🔍 Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (would cause existing functionality to not work)
- [ ] 📚 Documentation update
- [x] 🎨 Style/UI update
- [ ] ♻️ Code refactoring
- [ ] 📦 Dependency update
- [ ] 🧪 Test update
- [ ] 🔧 Configuration change

## ✅ Checklist
### Code Quality
- [x] 👀 I have performed a self-review
- [ ] 💬 I have added necessary comments
- [x] ⚠️ No new warnings or errors are generated
- [ ] ⚡ I have added/updated tests

### Git Hygiene
- [x] 🔍 My commits are small and have clear messages
- [x] 🔀 I have rebased on the latest main branch
- [x] 🧩 This PR is small and focused on a single change

## 🧪 Testing
- [x] 👉 Manual testing