### PR TITLE
fix: adjust stats amount text size and line height for xl breakpoint

### DIFF
--- a/src/components/widgets/Stats.astro
+++ b/src/components/widgets/Stats.astro
@@ -52,7 +52,7 @@ const styleStyle = {
               {amount && (
                 <div
                   class={twMerge(
-                    'font-heading text-primary text-3xl sm:text-[2.6rem] font-bold lg:text-5xl xl:text-6xl',
+                    'font-heading text-primary text-3xl sm:text-[2.6rem] font-bold lg:text-5xl xl:text-[48px] xl:leading-[56px]',
                     classes?.amount
                   )}
                   aria-label={`${title}: ${amount}`}


### PR DESCRIPTION
# Pull Request

## 📝 Description
Adjusted the font size and line height for the Stats component amount text in extra-large viewports.

### What changed?
- Modified the text size in the Stats component from `xl:text-6xl` to `xl:text-[48px]`
- Added `xl:leading-[56px]` to control the line height for extra-large viewports

## 📌 Additional Notes
This change provides more precise control over the typography in the Stats widget at the xl breakpoint.

## 🔗 Related Issues
🔄 Closes #

## 🔍 Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (would cause existing functionality to not work)
- [ ] 📚 Documentation update
- [x] 🎨 Style/UI update
- [ ] ♻️ Code refactoring
- [ ] 📦 Dependency update
- [ ] 🧪 Test update
- [ ] 🔧 Configuration change

## ✅ Checklist
### Code Quality
- [x] 👀 I have performed a self-review
- [ ] 💬 I have added necessary comments
- [x] ⚠️ No new warnings or errors are generated
- [ ] ⚡ I have added/updated tests

### Git Hygiene
- [x] 🔍 My commits are small and have clear messages
- [x] 🔀 I have rebased on the latest main branch
- [x] 🧩 This PR is small and focused on a single change

## 🧪 Testing
- [x] 👉 Manual testing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved font size and line height for stats display on extra-large screens, ensuring more precise and consistent appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->