### PR TITLE
Remove Ben's testimonial and update stats

### DIFF
--- a/src/components/sections/TestimonialsSection.astro
+++ b/src/components/sections/TestimonialsSection.astro
@@ -1,6 +1,5 @@
 ---
 import akosua from '~/assets/images/deacons/rukous_seurakunta_akosua.webp';
-import ben from '~/assets/images/deacons/rukous_seurakunta_ben.webp';
 import ida from '~/assets/images/deacons/rukous_seurakunta_ida.webp';
 import ahunsi_zoomed from '~/assets/images/elders/rukous_seurakunta_ahunsi_zoomed.webp';
 import mahi from '~/assets/images/elders/rukous_seurakunta_mahi.webp';
@@ -126,16 +125,6 @@ const t = useTranslations(lang);
         alt: '',
       },
       isPositive: false,
-    },
-    {
-      testimonial: t('testimonialBenwillis.t'),
-      name: t('testimonialBenwillis.name'),
-      job: t('testimonialBenwillis.job'),
-      image: {
-        src: ben,
-        alt: t('benImageAlt'),
-      },
-      isPositive: true,
     },
     {
       testimonial: t('testimonialGood1.t'),

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -88,8 +88,8 @@ const t = useTranslations(lang);
   <Stats
     id="lukuja2"
     stats={[
-      { title: t('stats2.title2'), amount: 22100, extra1: '+' },
-      { title: t('stats1.title1'), amount: 12 },
+      { title: t('stats2.title2'), amount: 102100, extra1: '+' },
+      { title: t('stats1.title1'), amount: 15 },
       { title: t('stats2.title3'), amount: 5, extra2: 'h' },
       // { title: t('stats2.title2'), amount: 2200, extra1: '+', extra2: '€' },
       // { title: t('stats2.title4'), amount: 4 },


### PR DESCRIPTION
# Pull Request

## 📝 Description
Removed Ben Willis's testimonial and updated church statistics on the homepage.

### What changed?
- Removed Ben Willis's testimonial and image import from the TestimonialsSection component
- Updated church statistics:
  - Increased the first stat from 22,100 to 102,100
  - Increased the number of members from 12 to 15

## 📌 Additional Notes
These changes reflect current church membership numbers and testimonial preferences.

## 🔗 Related Issues
🔄 Closes #

## 🔍 Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (would cause existing functionality to not work)
- [ ] 📚 Documentation update
- [x] 🎨 Style/UI update
- [ ] ♻️ Code refactoring
- [ ] 📦 Dependency update
- [ ] 🧪 Test update
- [ ] 🔧 Configuration change

## ✅ Checklist
### Code Quality
- [x] 👀 I have performed a self-review
- [ ] 💬 I have added necessary comments
- [x] ⚠️ No new warnings or errors are generated
- [ ] ⚡ I have added/updated tests

### Git Hygiene
- [x] 🔍 My commits are small and have clear messages
- [x] 🔀 I have rebased on the latest main branch
- [x] 🧩 This PR is small and focused on a single change

## 🧪 Testing
- [x] 👉 Manual testing